### PR TITLE
build: changed default repo branch to main, updated old references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,14 @@
 
-> 1. Make sure you follow our Contributing Guidelines: https://github.com/getndazn/pensieve/blob/master/CONTRIBUTING.md
+> 1. Make sure you follow our Contributing Guidelines: https://github.com/getndazn/pensieve/blob/main/CONTRIBUTING.md
 > 2. Do not remove any section of the template. If something is not applicable leave it empty, but leave it in the PR.
 > 3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged.
 
 
 # Description
 
-> Please include a summary of the change and which issue is fixed (when applicable).   
-> Please also include relevant motivation and context.   
-> List any dependencies that are required for this change.  
+> Please include a summary of the change and which issue is fixed (when applicable).
+> Please also include relevant motivation and context.
+> List any dependencies that are required for this change.
 
 ## How to verify this change
 
@@ -17,14 +17,14 @@ to make it easy for us to verify this works. The easier you make it for us
 to review a PR, the faster we can review and merge it.
 
 > Examples:
-> Screenshots - Showing the difference between your output and the master  
-> Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)  
-> Other - Anything else that comes to mind to help us evaluate  
+> Screenshots - Showing the difference between your output and output in the main branch
+> Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
+> Other - Anything else that comes to mind helping us evaluate
 
 
 ### Related issues
 
-> Add here the link to one or more issues that are related to this PR.  
+> Add here the link to one or more issues that are related to this PR.
 >
 > [#XXXXX](https://github.com/getndazn/pensieve/issues/XXXXX)
 

--- a/.publishrc
+++ b/.publishrc
@@ -4,7 +4,7 @@
     "uncommittedChanges": true,
     "untrackedFiles": true,
     "sensitiveData": true,
-    "branch": "master",
+    "branch": "main",
     "gitTag": false
   },
   "confirm": false,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ $ npm t
 ```bash
 $ # Create a new version
 $ npm version 0.1.0 -m "build: new npm version"
-$ git push origin master
+$ git push origin main
 ```
 
 2. Go to: https://github.com/getndazn/pensieve/releases & create a new release using the same version above.
@@ -54,7 +54,7 @@ $ git push origin master
 
 ## Contributing to the codebase
 
-* Implement your commits in a separated branch, branching off from master.
+* Implement your commits in a separated branch, branching off from the main branch.
 
 * Push your branch to the origin.
 
@@ -106,7 +106,7 @@ build: some informative description
 chore: some informative description
 ```
 
-TIP: [commitizen](https://github.com/commitizen/cz-cli) can help you following this convention.  
+TIP: [commitizen](https://github.com/commitizen/cz-cli) can help you following this convention.
 Run this command to install it in your local environment:
 
 ```


### PR DESCRIPTION
# Description

I changed the settings of this repository to set `main` as default branch. 
I also updated any hardcoded reference existing in this repository.

## How to verify this change

Verify that main is the default new branch. 
No old references can be found (upon searching in the code). 


### Related issues

-

# PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

# Checklist

- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't dropped
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally with my changes
- [x] Any *dependent changes have been merged and published* in downstream module
